### PR TITLE
Improve social regexes

### DIFF
--- a/social.js
+++ b/social.js
@@ -152,7 +152,7 @@ class Social extends HttpWorker {
 
   extractInstagram(html) {
     let instagram_profiles = html.match(
-      /https?:\/\/(www\.)?instagram\.com\/([A-Za-z0-9_](?:(?:[A-Za-z0-9_]|(?:\.(?!\.))){0,28}(?:[A-Za-z0-9_]))?)/gm
+      /https?:\/\/(www\.)?instagram\.com\/(?!p\/)([A-Za-z0-9_](?:(?:[A-Za-z0-9_]|(?:\.(?!\.))){0,28}(?:[A-Za-z0-9_]))?)/gm
     );
 
     if (instagram_profiles) {
@@ -164,7 +164,7 @@ class Social extends HttpWorker {
 
   extractFacebook(html) {
     let facebook_urls = html.match(
-      /http(s)?:\/\/(www\.)?(facebook|fb)\.com\/[A-z0-9_\-\.]+\/?/gm
+      /http(s)?:\/\/(www\.)?(facebook|fb)\.com\/(?!share\.php)[A-z0-9_\-\.]+\/?/gm
     );
 
     if (facebook_urls) {
@@ -176,7 +176,7 @@ class Social extends HttpWorker {
 
   extractTwitter(html) {
     let twitter = html.match(
-      /http(s)?:\/\/(.*\.)?twitter\.com\/[A-z0-9_]{1,100}\/?/gm
+      /http(s)?:\/\/(.*\.)?twitter\.com\/(?!intent\/)[A-z0-9_]{1,100}\/?/gm
     );
 
     if (twitter) {


### PR DESCRIPTION
The goal of this script is to fetch the social links that could be attributed to a site we're scraping
posts, intents, and share links are not of interest.

I added negative lookahead to remove certain scenarios.

- /p/ in Instagram URL is not favorable, we don't want posts we want a profile URL.
- /share.php when fetching Facebook URLs we don't want a share link.
- /intent/ when scraping twitter URLs we don't want intent links.